### PR TITLE
:bug: Deconstruct throws exception when result is fail

### DIFF
--- a/src/TheNoobs.Results/Result.cs
+++ b/src/TheNoobs.Results/Result.cs
@@ -23,12 +23,15 @@ public record Result<T> : IResult
     }
 
     public T Value => IsSuccess ? _value : throw new InvalidResultValueException();
+    
     public Type ResultType => typeof(T);
+    
     public bool IsSuccess { get; }
     
     public Fail? Fail { get; }
 
     object IResult.GetValue() => Value!;
+    
     public virtual Result<TValue> GetValue<TValue>()
     {
         if (!IsSuccess)
@@ -61,7 +64,8 @@ public record Result<T> : IResult
 
     public void Deconstruct(out T? value, out Fail? fail)
     {
-        value = Value;
+        // We should return the field here because the property will throw an exception for failures
+        value = _value;
         fail = Fail;
     }
 }

--- a/tests/TheNoobs.Results.Tests/ResultTests.cs
+++ b/tests/TheNoobs.Results.Tests/ResultTests.cs
@@ -30,14 +30,14 @@ public class ResultTests
         var result = new Result<string>(new TestFail());
         result.GetValue<string>().Fail.Should().BeOfType<TestFail>();
     }
-    
+
     [Fact]
     public void GivenSuccessResult_WhenGettingTypedValue_ThenShouldReturnTheValue()
     {
         var result = new Result<string>("test");
         result.GetValue<string>().Value.Should().Be("test");
     }
-    
+
     [Fact]
     public void GivenSuccessResult_WhenGettingMismatchedTypedValue_ThenShouldReturnNotFoundFail()
     {
@@ -128,7 +128,8 @@ public class ResultTests
 
     [Theory]
     [MemberData(nameof(GetTypes))]
-    public void GivenFailTypes_WhenCreatingResultFromType_ThenShouldReturnTheCorrectTypeInstanceWithMessageAndCode(Fail fail, Type type, string message, string code)
+    public void GivenFailTypes_WhenCreatingResultFromType_ThenShouldReturnTheCorrectTypeInstanceWithMessageAndCode(
+        Fail fail, Type type, string message, string code)
     {
         fail.Should().NotBeNull();
         fail.Should().BeOfType(type);
@@ -136,22 +137,87 @@ public class ResultTests
         fail.Message.Should().Be(message);
     }
 
+    [Fact]
+    public void GivenFailResult_Deconstruct_Should_Return_Default_Value()
+    {
+        Result<int> fail = new TestFail();
+        var (value, _) = fail;
+        value.Should().Be(default);
+    }
+
+    [Fact]
+    public void GivenSuccessResult_Deconstruct_ShouldReturnNullForFailValue()
+    {
+        Result<int> success = 1;
+        var (_, fail) = success;
+        fail.Should().BeNull();
+    }
+
     public static IEnumerable<object[]> GetTypes()
     {
-        yield return new object[] { new BadRequestFail(), typeof(BadRequestFail), "Bad request", "bad_request" };
-        yield return new object[] { new ValidationFail(), typeof(ValidationFail), "Validation failed", "validation_failed" };
-        yield return new object[] { new TimeoutFail(), typeof(TimeoutFail), "Request timed out", "timeout" };
-        yield return new object[] { new ServerErrorFail(), typeof(ServerErrorFail), "Internal server error", "server_error" };
-        yield return new object[] { new DuplicateResourceFail(), typeof(DuplicateResourceFail), "Duplicate resource found", "duplicate_resource" };
-        yield return new object[] { new UnauthorizedFail(), typeof(UnauthorizedFail), "Unauthorized access", "unauthorized" };
-        yield return new object[] { new UnprocessableEntityFail(), typeof(UnprocessableEntityFail), "Unprocessable entity", "unprocessable_entity" };
-        yield return new object[] { new ConfigurationErrorFail(), typeof(ConfigurationErrorFail), "Configuration error", "config_error" };
-        yield return new object[] { new NotFoundFail(), typeof(NotFoundFail), "Resource not found", "not_found" };
-        yield return new object[] { new InsufficientPermissionsFail(), typeof(InsufficientPermissionsFail), "Insufficient permissions", "insufficient_permissions" };
-        yield return new object[] { new InvalidInputFail(), typeof(InvalidInputFail), "Invalid input", "invalid_input" };
-        yield return new object[] { new DataProcessingFail(), typeof(DataProcessingFail), "Error processing data", "data_processing_error" };
-        yield return new object[] { new ResourceLockedFail(), typeof(ResourceLockedFail), "Resource is locked", "resource_locked" };
-        yield return new object[] { new ThirdPartyServiceErrorFail(), typeof(ThirdPartyServiceErrorFail), "Error from third-party service", "third_party_error" };
-        yield return new object[] { new RateLimitExceededFail(), typeof(RateLimitExceededFail), "Rate limit exceeded", "rate_limit_exceeded" };
+        yield return [new BadRequestFail(), typeof(BadRequestFail), "Bad request", "bad_request"];
+        yield return [new ValidationFail(), typeof(ValidationFail), "Validation failed", "validation_failed"];
+        yield return [new TimeoutFail(), typeof(TimeoutFail), "Request timed out", "timeout"];
+        yield return [new ServerErrorFail(), typeof(ServerErrorFail), "Internal server error", "server_error"];
+        
+        yield return
+        [
+            new DuplicateResourceFail(), 
+            typeof(DuplicateResourceFail), 
+            "Duplicate resource found", 
+            "duplicate_resource"
+        ];
+        
+        yield return [new UnauthorizedFail(), typeof(UnauthorizedFail), "Unauthorized access", "unauthorized"];
+        
+        yield return
+        [
+            new UnprocessableEntityFail(), 
+            typeof(UnprocessableEntityFail), 
+            "Unprocessable entity",
+            "unprocessable_entity"
+        ];
+        
+        yield return
+        [
+            new ConfigurationErrorFail(), typeof(ConfigurationErrorFail), "Configuration error", "config_error"
+        ];
+        
+        yield return [new NotFoundFail(), typeof(NotFoundFail), "Resource not found", "not_found"];
+        
+        yield return
+        [
+            new InsufficientPermissionsFail(), 
+            typeof(InsufficientPermissionsFail), 
+            "Insufficient permissions",
+            "insufficient_permissions"
+        ];
+        yield return [new InvalidInputFail(), typeof(InvalidInputFail), "Invalid input", "invalid_input"];
+        
+        yield return
+        [
+            new DataProcessingFail(), 
+            typeof(DataProcessingFail), 
+            "Error processing data", 
+            "data_processing_error"
+        ];
+        
+        yield return [new ResourceLockedFail(), typeof(ResourceLockedFail), "Resource is locked", "resource_locked"];
+        
+        yield return
+        [
+            new ThirdPartyServiceErrorFail(), 
+            typeof(ThirdPartyServiceErrorFail),
+            "Error from third-party service",
+            "third_party_error"
+        ];
+        
+        yield return
+        [
+            new RateLimitExceededFail(), 
+            typeof(RateLimitExceededFail),
+            "Rate limit exceeded", 
+            "rate_limit_exceeded"
+        ];
     }
 }

--- a/tests/TheNoobs.Results.Tests/ResultTests.cs
+++ b/tests/TheNoobs.Results.Tests/ResultTests.cs
@@ -138,7 +138,7 @@ public class ResultTests
     }
 
     [Fact]
-    public void GivenFailResult_Deconstruct_Should_Return_Default_Value()
+    public void GivenFailResult_Deconstruct_ShouldReturnDefaultValue()
     {
         Result<int> fail = new TestFail();
         var (value, _) = fail;
@@ -146,11 +146,29 @@ public class ResultTests
     }
 
     [Fact]
-    public void GivenSuccessResult_Deconstruct_ShouldReturnNullForFailValue()
+    public void GivenFailResult_DeconstructShouldReturnFail()
+    {
+        var expected = new TestFail();
+        Result<int> fail = expected;
+        var (_, actual) = fail;
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void GivenSuccessResult_Deconstruct_ShouldReturnNullFail()
     {
         Result<int> success = 1;
         var (_, fail) = success;
         fail.Should().BeNull();
+    }
+
+    [Fact]
+    public void GivenSuccessResult_Deconstruct_ShouldReturnValue()
+    {
+        var expected = 1;
+        Result<int> success = expected;
+        var (actual, _) = success;
+        actual.Should().Be(expected);
     }
 
     public static IEnumerable<object[]> GetTypes()


### PR DESCRIPTION
# Description

Deconstruct is not working when result is failure. It throws `InvalidResultValueException` because it tries to get the value from the Property `Value` which executes the validation and throws it if result is a fail.

Should not `Deconstruct` return the default value of the `_value` field instead?

## Type of change

- [x] :bug: Bug fix (non-breaking change which fixes an issue)
- [ ] :sparkles: New feature (non-breaking change which adds functionality)
- [ ] :boom: Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] :memo: This change requires a documentation update

### How Has This Been Tested?

- [x] :white_check_mark: All tests were ran and new tests were added (if needed)
- [x] Given fail result, `Deconstruct` should return default value;
- [x] Given fail result, `Deconstruct` should return the same fail result;
- [x] Given success result, `Deconstruct` should return null fail result;
- [x] Given success result, `Deconstruct` should return the same value;

### Definition of Done

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Does this add new dependencies?
